### PR TITLE
Post to discord

### DIFF
--- a/SquadForger/MainWindow.xaml
+++ b/SquadForger/MainWindow.xaml
@@ -23,8 +23,8 @@
                 <Frame Content="{Binding VisualizePage}" NavigationUIVisibility="Hidden" />
             </TabItem>
             <TabItem Header = "Post to Discord" Background="LightGray">
-                <Label Content="Post to Discord page comes here"/>
-            </TabItem>
+				<Frame Content="{Binding DiscordPage}" NavigationUIVisibility="Hidden"/>
+			</TabItem>
             <TabItem Header="Info" Background="LightGray">
                 <TextBlock Margin="10">
                     <TextBlock Text="Github repository: "/>

--- a/SquadForger/SquadForger.csproj
+++ b/SquadForger/SquadForger.csproj
@@ -124,9 +124,13 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="ViewModel\DiscordVM.cs" />
     <Compile Include="ViewModel\MainVM.cs" />
     <Compile Include="ViewModel\SquadVM.cs" />
     <Compile Include="ViewModel\VisualizeVM.cs" />
+    <Compile Include="View\DiscordView.xaml.cs">
+      <DependentUpon>DiscordView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="View\SquadView.xaml.cs">
       <DependentUpon>SquadView.xaml</DependentUpon>
     </Compile>
@@ -145,6 +149,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="View\DiscordView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="View\SquadView.xaml" />
     <Page Include="View\VisualizeView.xaml" />
   </ItemGroup>

--- a/SquadForger/View/DiscordView.xaml
+++ b/SquadForger/View/DiscordView.xaml
@@ -1,0 +1,27 @@
+﻿<Page x:Class="SquadForger.View.DiscordView"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:SquadForger.View"
+	  xmlns:vm="clr-namespace:SquadForger.ViewModel"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="DiscordView">
+	<Page.DataContext>
+		<vm:DiscordVM/>
+	</Page.DataContext>
+	<Page.Background>
+		<SolidColorBrush Color="SlateGray"/>
+	</Page.Background>
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition/>
+			<RowDefinition MaxHeight="50"/>
+		</Grid.RowDefinitions>
+		<ScrollViewer Background="#B3CCE6">
+			<TextBlock Text="{Binding TextToSend}" Margin="10"/>
+		</ScrollViewer>
+		<Button Command="{Binding PostToDiscordCommand}" Content="Send to discord" Grid.Row="1" Height="40" Width="100"/>
+	</Grid>
+</Page>

--- a/SquadForger/View/DiscordView.xaml.cs
+++ b/SquadForger/View/DiscordView.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace SquadForger.View
+{
+	/// <summary>
+	/// Interaction logic for DiscordView.xaml
+	/// </summary>
+	public partial class DiscordView : Page
+	{
+		public DiscordView()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/SquadForger/ViewModel/DiscordVM.cs
+++ b/SquadForger/ViewModel/DiscordVM.cs
@@ -1,8 +1,10 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System.Text;
 using Discord.Webhook;
-using System.Resources;
 using CommunityToolkit.Mvvm.Input;
+using System.Configuration;
+using System;
+using System.Windows;
 
 namespace SquadForger.ViewModel
 {
@@ -19,7 +21,9 @@ namespace SquadForger.ViewModel
 		public DiscordVM()
 		{
 			PostToDiscordCommand = new RelayCommand(PostToDiscord);
-			TextToSend = GetLongTestText();
+
+			// Temporary!
+			TextToSend = "This is a test message";
 		}
 
 		private async void PostToDiscord()
@@ -29,9 +33,16 @@ namespace SquadForger.ViewModel
 				return;
 			}
 			
-			string webhooklink = "Extract from PrivateData.config";
-			DiscordWebhookClient webhook = new DiscordWebhookClient(webhooklink);
-			await webhook.SendMessageAsync(TextToSend);
+			try
+            {
+				string webhooklink = ConfigurationManager.AppSettings.Get("dev_webhook");
+				DiscordWebhookClient webhook = new DiscordWebhookClient(webhooklink);
+				await webhook.SendMessageAsync(TextToSend);
+            }
+			catch (Exception e)
+            {
+				MessageBox.Show($"Exception: {e.Message}");
+            }
 		}
 
 		private static string GetLongTestText(int lines = 30)

--- a/SquadForger/ViewModel/DiscordVM.cs
+++ b/SquadForger/ViewModel/DiscordVM.cs
@@ -1,0 +1,47 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System.Text;
+using Discord.Webhook;
+using System.Resources;
+using CommunityToolkit.Mvvm.Input;
+
+namespace SquadForger.ViewModel
+{
+	public class DiscordVM : ObservableObject
+	{
+		private string _textToSend = "<empty>";
+		public string TextToSend
+		{
+			get => _textToSend;
+			private set { _textToSend = value; OnPropertyChanged(nameof(TextToSend)); }
+		}
+		public RelayCommand PostToDiscordCommand { get; private set; }
+
+		public DiscordVM()
+		{
+			PostToDiscordCommand = new RelayCommand(PostToDiscord);
+			TextToSend = GetLongTestText();
+		}
+
+		private async void PostToDiscord()
+		{
+			if (TextToSend.Equals("<empty>"))
+			{
+				return;
+			}
+			
+			string webhooklink = "Extract from PrivateData.config";
+			DiscordWebhookClient webhook = new DiscordWebhookClient(webhooklink);
+			await webhook.SendMessageAsync(TextToSend);
+		}
+
+		private static string GetLongTestText(int lines = 30)
+		{
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < lines; ++i)
+			{
+				sb.AppendLine("This is a very long sentence just to fill some space. Lorem ispum or something I don't know.");
+			}
+			return sb.ToString();
+		}
+	}
+}

--- a/SquadForger/ViewModel/MainVM.cs
+++ b/SquadForger/ViewModel/MainVM.cs
@@ -11,6 +11,7 @@ namespace SquadForger.ViewModel
         public RelayCommand OpenGithubRepoCommand { get; private set; }
         public SquadView SquadPage { get; private set; } = new SquadView();
         public VisualizeView VisualizePage { get; private set; } = new VisualizeView();
+        public DiscordView DiscordPage { get; private set; } = new DiscordView();
 
         public MainVM()
         {


### PR DESCRIPTION
Setting a correct webhook in the `PrivateData.config` makes it possible to use the `Send to Discord` button.

A preview can be seen as well. This is the raw text that will be sent, so code blocks, rich text or other markdown things will be shown as their raw text and not their equivalent.