### PR TITLE
Fixes #23: Better Webhook Integration

### DIFF
--- a/SquadForger/App.config
+++ b/SquadForger/App.config
@@ -3,9 +3,10 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
-  <appSettings configSource="PrivateData.config">
-    
+  <appSettings >
+      <add key="dev_webhook" value="" />
   </appSettings>
+
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/SquadForger/Components/BindabalePasswordBox.xaml
+++ b/SquadForger/Components/BindabalePasswordBox.xaml
@@ -1,0 +1,10 @@
+<UserControl x:Class="SquadForger.Components.BindabalePasswordBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:SquadForger.Components"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300">
+    <PasswordBox x:Name="passwordBox"  Width="230" Height="20" Margin="10" Background="#9e8cbb" PasswordChanged="PasswordBox_OnPasswordChanged" ></PasswordBox>
+</UserControl>

--- a/SquadForger/Components/BindabalePasswordBox.xaml.cs
+++ b/SquadForger/Components/BindabalePasswordBox.xaml.cs
@@ -1,0 +1,27 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace SquadForger.Components
+{
+    public partial class BindabalePasswordBox : UserControl
+    {
+        public static readonly DependencyProperty PasswordProperty = DependencyProperty.Register(
+           "Password", typeof(string), typeof(BindabalePasswordBox), new PropertyMetadata("Discord Webhook ID"));
+
+        public string Password  
+        {
+            get { return (string)GetValue(PasswordProperty); }
+            set { SetValue(PasswordProperty, value); }
+        }
+        
+        public BindabalePasswordBox()
+        {
+            InitializeComponent();
+        }
+
+        private void PasswordBox_OnPasswordChanged(object sender, RoutedEventArgs e)
+        {
+            Password=passwordBox.Password;
+        }
+    }
+}

--- a/SquadForger/SquadForger.csproj
+++ b/SquadForger/SquadForger.csproj
@@ -242,6 +242,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Components\BindabalePasswordBox.xaml.cs">
+      <DependentUpon>BindabalePasswordBox.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Converter\TextToVisibilityConverter.cs" />
     <Compile Include="Model\Champions.cs" />
     <Compile Include="Model\LeagueVersion.cs" />
@@ -262,6 +265,7 @@
     <Compile Include="View\SquadView.xaml.cs">
       <DependentUpon>SquadView.xaml</DependentUpon>
     </Compile>
+    <Page Include="Components\BindabalePasswordBox.xaml" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -301,9 +305,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="packages.config" />
-    <None Include="PrivateData.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+ 
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SquadForger/View/DiscordView.xaml
+++ b/SquadForger/View/DiscordView.xaml
@@ -4,6 +4,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:SquadForger.View"
+      xmlns:components = "clr-namespace:SquadForger.Components"
 	  xmlns:vm="clr-namespace:SquadForger.ViewModel"
       mc:Ignorable="d" 
       Background="Transparent"
@@ -73,6 +74,7 @@
 		<Grid.RowDefinitions>
 			<RowDefinition/>
 			<RowDefinition MaxHeight="50"/>
+            <RowDefinition MaxHeight="50"/>
 		</Grid.RowDefinitions>
 		<StackPanel>
 			
@@ -93,13 +95,26 @@
                     Margin="0,0,10,0"
                     Background="#e3c57e"
                     Foreground="black"/>
-			<Button Command="{Binding PostToDiscordCommand}"
+			<Button Style="{DynamicResource DiscordViewButtonTemplate}" Command="{Binding PostToDiscordCommand}"
                     Content="Send to discord"
                     Height="40" 
                     Width="100"
                     Background="#e3c57e"
                     Foreground="black"/>
+           
+            
 		</StackPanel>
-		
+        <StackPanel Grid.Row="2" Orientation="Horizontal">
+          
+            <components:BindabalePasswordBox Password="{Binding WebhookID,UpdateSourceTrigger=PropertyChanged , Mode=TwoWay}"/>
+            <Button Style="{DynamicResource DiscordViewButtonTemplate}" Command="{Binding UpdateWebhookIDCommand}"
+                    Content="Update Webhook ID"
+                    Height="40" 
+                    Width="140"
+                    Background="#e3c57e"
+                    Foreground="black"/>
+            
+        </StackPanel>
+       
 	</Grid>
 </UserControl>


### PR DESCRIPTION
- Removed privateData.config
- You can add your Discord Webhook ID from Discord Tab
- PasswordBox is used for privacy
- Warnings are given if the input is invalid, it must match with @"^https:\/\/discord\.com\/api\/webhooks\/\d+\/[A-Za-z0-9_-]+$"
![Screenshot 2024-09-29 120728](https://github.com/user-attachments/assets/4ca50ef4-91ac-42a2-905a-071aa6823d82)
